### PR TITLE
feat: support line suffixes

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -165,6 +165,37 @@ pub trait DocAllocator<'a> {
         }
     }
 
+    /// Pushes some content to the end of the current line.
+    ///
+    /// Multiple `line_suffix` calls accumulate in order and are all flushed together when a line
+    /// break occurs or rendering ends.
+    ///
+    /// ```
+    /// use prettyless::{Arena, DocAllocator};
+    ///
+    /// let arena = Arena::new();
+    ///
+    /// let doc = (arena.text("a")
+    ///     + arena.line_suffix(" // 1")
+    ///     + arena.line()
+    ///     + arena.line_suffix(" // 2")
+    ///     + arena.text("b"))
+    /// .group();
+    /// assert_eq!(doc.print(5).to_string(), "a b // 1 // 2");
+    ///
+    /// let doc = arena.text("a")
+    ///     + arena.line_suffix(" // 1")
+    ///     + arena.hardline()
+    ///     + arena.line_suffix(" // 2")
+    ///     + arena.text("b");
+    /// assert_eq!(doc.print(5).to_string(), "a // 1\nb // 2");
+    /// ```
+    #[inline]
+    fn line_suffix(&'a self, doc: impl Pretty<'a, Self>) -> DocBuilder<'a, Self> {
+        let doc = doc.pretty(self).into_doc();
+        DocBuilder(self, Doc::LineSuffix(doc).into())
+    }
+
     /// Allocate a document concatenating the given documents.
     #[inline]
     fn concat<I>(&'a self, docs: I) -> DocBuilder<'a, Self>

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -106,6 +106,27 @@ where
         Self(allocator, doc.into())
     }
 
+    /// Make `self` a line suffix.
+    ///
+    /// ```
+    /// use prettyless::{Arena, DocAllocator};
+    ///
+    /// let arena = Arena::new();
+    /// let doc = arena.text(" // comment").as_line_suffix() + arena.text("x");
+    ///
+    /// assert_eq!(doc.print(80).to_string(), "x // comment");
+    /// ```
+    #[inline]
+    pub fn as_line_suffix(self) -> Self {
+        match *self.1 {
+            Doc::Nil | Doc::LineSuffix(_) => self,
+            _ => {
+                let Self(allocator, this) = self;
+                Self(allocator, Doc::LineSuffix(allocator.alloc_cow(this)).into())
+            }
+        }
+    }
+
     /// Acts as `self` when laid out on multiple lines and acts as `that` when laid out on a single line.
     ///
     /// ```

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -35,7 +35,8 @@ where
     HardLine,
 
     // Structural
-    Append(T, T), // sequencing
+    Append(T, T),  // Sequencing
+    LineSuffix(T), // A document that is appended to the end of the current line.
 
     // Indentation and Alignment
     Nest(isize, T),  // Changes the indentation level
@@ -135,6 +136,8 @@ where
                 });
                 f.finish()
             }
+            Doc::LineSuffix(ref doc) => write_compact(f, doc, "LineSuffix"),
+
             Doc::Nest(off, ref doc) => {
                 write!(f, "Nest({off}, ",)?;
                 doc.fmt(f)?;

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -215,6 +215,31 @@ fn union2() {
 }
 
 #[test]
+fn line_suffix_with_union() {
+    let arena = Arena::new();
+
+    let doc = arena.text("a")
+        + arena.line_suffix(" // 1")
+        + arena.text("a")
+        + (arena.line_suffix(" // 3") + arena.text("6666666"))
+            .union(arena.line_suffix(" // 4") + arena.text("77"));
+
+    test!(5, doc, "aa77 // 1 // 4");
+}
+
+#[test]
+fn line_suffix_with_union2() {
+    let arena = Arena::new();
+
+    let doc = arena.line_suffix(" // 1")
+        + arena.text("a")
+        + (arena.line_suffix(" // 3") + arena.hardline() + arena.text("xxxxxxx"))
+            .union(arena.line_suffix(" // 4") + arena.text("yyy"));
+
+    test!(5, doc, "ayyy // 1 // 4");
+}
+
+#[test]
 fn usize_max_value() {
     let doc = BoxDoc::group(
         BoxDoc::text("test")


### PR DESCRIPTION
This PR introduces line suffixes, which are flushed to the end of the line and are not affected by line width.