### PR TITLE
feat: support expand_parent

### DIFF
--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -105,6 +105,20 @@ pub trait DocAllocator<'a> {
         doc.pretty(self).flat_alt(self.nil())
     }
 
+    /// Make the parent group break
+    ///
+    /// ```
+    /// use prettyless::DocAllocator;
+    ///
+    /// let arena = prettyless::Arena::new();
+    /// let doc = (arena.line() + arena.expand_parent()).group();
+    /// assert_eq!(doc.print(80).to_string(), "\n");
+    /// ```
+    #[inline]
+    fn expand_parent(&'a self) -> DocBuilder<'a, Self> {
+        DocBuilder(self, Doc::ExpandParent.into())
+    }
+
     /// Allocate a document containing the text `t.to_string()`.
     ///
     /// The given text must not contain line breaks.

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -39,9 +39,10 @@ where
     Nest(isize, T), // indenting
 
     // Choices
+    ExpandParent,       // make the parent group break
     Flatten(T),         // always flat inside
-    Group(T),           // try flat vs broken
     BreakOrFlat(T, T),  // break vs flat
+    Group(T),           // try flat vs broken
     Union(T, T),        // alternative layouts
     PartialUnion(T, T), // like union, but only fit on the first line
 
@@ -134,6 +135,8 @@ where
                 write!(f, ")")
             }
 
+            Doc::ExpandParent => f.write_str("ExpandParent"),
+            Doc::Flatten(ref doc) => write_compact(f, doc, "Flatten"),
             Doc::BreakOrFlat(ref x, ref y) => match (&**x, &**y) {
                 (Doc::HardLine, Doc::Text(Text::Borrowed(" "))) => f.write_str("LineOrSpace"),
                 (Doc::HardLine, Doc::Nil) => f.write_str("LineOrNil"),
@@ -141,7 +144,6 @@ where
                 (Doc::Nil, _) => f.debug_tuple("WhenFlat").field(y).finish(),
                 _ => f.debug_tuple("FlatOrBreak").field(y).field(x).finish(),
             },
-            Doc::Flatten(ref doc) => write_compact(f, doc, "Flatten"),
             Doc::Group(ref doc) => match &**doc {
                 Doc::BreakOrFlat(x, y)
                     if matches!(
@@ -370,6 +372,12 @@ macro_rules! impl_doc_methods {
             #[inline]
             pub fn space() -> Self {
                 Doc::Text(Text::Borrowed(" ")).into()
+            }
+
+            /// Make the parent group break
+            #[inline]
+            pub fn expand_parent() -> Self {
+                Doc::ExpandParent.into()
             }
         }
 

--- a/src/render/fit.rs
+++ b/src/render/fit.rs
@@ -123,15 +123,9 @@ where
                         cmd.doc = inner;
                     }
 
+                    Doc::ExpandParent => break,
                     Doc::Flatten(ref inner) => {
                         cmd.mode = Mode::Flat;
-                        cmd.doc = inner;
-                    }
-                    Doc::Group(ref inner) => {
-                        if mode == Mode::Break && self.fitting(inner, self.pos, indent, Mode::Flat)
-                        {
-                            cmd.mode = Mode::Flat;
-                        }
                         cmd.doc = inner;
                     }
                     Doc::BreakOrFlat(ref break_doc, ref flat_doc) => {
@@ -139,6 +133,13 @@ where
                             Mode::Break => break_doc,
                             Mode::Flat => flat_doc,
                         };
+                    }
+                    Doc::Group(ref inner) => {
+                        if mode == Mode::Break && self.fitting(inner, self.pos, indent, Mode::Flat)
+                        {
+                            cmd.mode = Mode::Flat;
+                        }
+                        cmd.doc = inner;
                     }
                     Doc::Union(ref left, ref right) => {
                         if mode == Mode::Flat {
@@ -240,6 +241,12 @@ where
                         });
                     }
 
+                    Doc::ExpandParent => {
+                        if mode == Mode::Flat {
+                            return false;
+                        }
+                        break;
+                    }
                     Doc::Flatten(ref inner) => {
                         mode = Mode::Flat;
                         doc = inner;


### PR DESCRIPTION
This can be used to prevent line comment from being inlined.