### PR TITLE
feat: do not allocate common texts in the arena

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -94,7 +94,7 @@ where
 
         let Self(allocator, this) = self;
         if n == 0 {
-            return Self(allocator, Doc::Nil.into());
+            return allocator.nil();
         }
 
         let this = allocator.alloc_cow(this);


### PR DESCRIPTION
When the arena try to allocate texts, it avoids allocating commonly-used short string literals.

It also adds utility function `DocAllocator::ascii_text` to avoid checking unicode width.