### PR TITLE
feat: add some utility functions for docs

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -35,6 +35,13 @@ where
         }
     }
 
+    pub fn into_ref(self) -> Self {
+        match self.1 {
+            BuildDoc::DocPtr(_) => self,
+            BuildDoc::Doc(d) => Self(self.0, BuildDoc::DocPtr(self.0.alloc(d))),
+        }
+    }
+
     pub(crate) fn into_plain_doc(self) -> Doc<'a, D::Doc> {
         match self.1 {
             BuildDoc::DocPtr(_) => unreachable!(),

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -62,6 +62,16 @@ where
 
 impl<'a, T> Doc<'a, T>
 where
+    T: DocPtr<'a>,
+{
+    #[inline]
+    pub fn is_nil(&self) -> bool {
+        matches!(self, Self::Nil)
+    }
+}
+
+impl<'a, T> Doc<'a, T>
+where
     T: StaticDoc<'a>,
 {
     /// The text `t.to_string()`.
@@ -617,5 +627,14 @@ mod tests {
     "4",
 ]"#
         )
+    }
+
+    #[test]
+    fn doc_is_nil() {
+        let arena = Arena::new();
+        assert!(arena.nil().is_nil());
+        assert!((arena.nil() + arena.nil()).is_nil());
+        assert!(arena.text("").is_nil());
+        assert!(!arena.text(" ").is_nil());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,6 +263,28 @@ where
     }
 }
 
+impl<'a, D, T, const N: usize> Pretty<'a, D> for [T; N]
+where
+    D: ?Sized + DocAllocator<'a>,
+    T: Pretty<'a, D>,
+{
+    /// Concat items of self with arena.
+    ///
+    /// ```
+    /// use prettyless::{Arena, DocAllocator, Pretty};
+    /// let arena = Arena::new();
+    ///
+    /// let doc = arena.text("#") + ["1", "2", "3", "4"];
+    /// assert_eq!(doc.print(80).to_string(), "#1234");
+    ///
+    /// let doc = ["a", "b", "c"].pretty(&arena);
+    /// assert_eq!(doc.print(80).to_string(), "abc");
+    /// ```
+    fn pretty(self, allocator: &'a D) -> DocBuilder<'a, D> {
+        allocator.concat(self)
+    }
+}
+
 /// Concatenates a number of documents (or values that can be converted into a document via the
 /// `Pretty` trait, like `&str`)
 ///


### PR DESCRIPTION
## Added

- `Doc::is_nil`
- `DocBuilder::into_ref` to make inner ref, which can help prepare for cloning.
- `[T; N]::pretty`, making it easier to concat.