### PR TITLE
feat: deprecate `hardline` in favor of `hard_line`

### DIFF
--- a/examples/trees.rs
+++ b/examples/trees.rs
@@ -24,8 +24,8 @@ impl<'a> Forest<'a> {
         } else {
             allocator
                 .text("[")
-                .append(allocator.hardline().append(self.pretty(allocator)).nest(2))
-                .append(allocator.hardline())
+                .append(allocator.hard_line().append(self.pretty(allocator)).nest(2))
+                .append(allocator.hard_line())
                 .append(allocator.text("]"))
         }
     }
@@ -36,7 +36,7 @@ impl<'a> Forest<'a> {
         D::Doc: Clone,
     {
         let forest = self.0;
-        let separator = allocator.text(",").append(allocator.hardline());
+        let separator = allocator.text(",").append(allocator.hard_line());
         allocator.intersperse(forest.iter().map(|tree| tree.pretty(allocator)), separator)
     }
 }

--- a/src/alloc.rs
+++ b/src/alloc.rs
@@ -41,9 +41,16 @@ pub trait DocAllocator<'a> {
         DocBuilder(self, Doc::Fail.into())
     }
 
-    /// Allocate a single hardline.
+    /// Allocate a single hard line.
+    #[deprecated(note = "use `hard_line` instead")]
     #[inline]
     fn hardline(&'a self) -> DocBuilder<'a, Self> {
+        DocBuilder(self, Doc::HardLine.into())
+    }
+
+    /// Allocate a single hard line.
+    #[inline]
+    fn hard_line(&'a self) -> DocBuilder<'a, Self> {
         DocBuilder(self, Doc::HardLine.into())
     }
 
@@ -55,7 +62,7 @@ pub trait DocAllocator<'a> {
     /// A line acts like a `\n` but behaves like `space` if it is grouped on a single line.
     #[inline]
     fn line(&'a self) -> DocBuilder<'a, Self> {
-        self.hardline().flat_alt(self.space())
+        self.hard_line().flat_alt(self.space())
     }
 
     /// Acts like `line` but behaves like `nil` if grouped on a single line
@@ -80,7 +87,7 @@ pub trait DocAllocator<'a> {
     /// ```
     #[inline]
     fn line_(&'a self) -> DocBuilder<'a, Self> {
-        self.hardline().flat_alt(self.nil())
+        self.hard_line().flat_alt(self.nil())
     }
 
     /// A `softline` acts like `space` if the document fits the page, otherwise like `line`
@@ -190,7 +197,7 @@ pub trait DocAllocator<'a> {
     ///
     /// let doc = arena.text("a")
     ///     + arena.line_suffix(" // 1")
-    ///     + arena.hardline()
+    ///     + arena.hard_line()
     ///     + arena.line_suffix(" // 2")
     ///     + arena.text("b");
     /// assert_eq!(doc.print(5).to_string(), "a // 1\nb // 2");

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -277,8 +277,8 @@ where
     /// let arena = Arena::new();
     /// let doc = (
     ///     arena.text("a")
-    ///     + (arena.text("b") + arena.hardline() + arena.text("c")).dedent_to_root()
-    ///     + arena.hardline()
+    ///     + (arena.text("b") + arena.hard_line() + arena.text("c")).dedent_to_root()
+    ///     + arena.hard_line()
     ///     + arena.text("e")
     /// ).indent(4);
     /// assert_eq!(doc.print(10).to_string(), "ab\nc\n    e");
@@ -308,7 +308,7 @@ where
     ///     "lorem",
     ///     " ",
     ///     arena.intersperse(["ipsum", "dolor"].iter().cloned(), arena.line_()).align(),
-    ///     arena.hardline(),
+    ///     arena.hard_line(),
     ///     "next",
     /// ];
     /// assert_eq!(
@@ -334,8 +334,8 @@ where
     /// use prettyless::{Arena, DocAllocator};
     ///
     /// let arena = Arena::new();
-    /// let doc = (arena.text("short") + arena.hardline() + arena.text("long long long"))
-    ///        .union(arena.text("short") + arena.hardline() + arena.text("short"));
+    /// let doc = (arena.text("short") + arena.hard_line() + arena.text("long long long"))
+    ///        .union(arena.text("short") + arena.hard_line() + arena.text("short"));
     /// assert_eq!(doc.print(10).to_string(), "short\nshort");
     /// ```
     #[inline]
@@ -355,8 +355,8 @@ where
     /// use prettyless::{Arena, DocAllocator};
     ///
     /// let arena = Arena::new();
-    /// let doc = (arena.text("short") + arena.hardline() + arena.text("long long long"))
-    ///        .partial_union(arena.text("short") + arena.hardline() + arena.text("short"));
+    /// let doc = (arena.text("short") + arena.hard_line() + arena.text("long long long"))
+    ///        .partial_union(arena.text("short") + arena.hard_line() + arena.text("short"));
     /// assert_eq!(doc.print(10).to_string(), "short\nlong long long");
     /// ```
     #[inline]

--- a/src/doc.rs
+++ b/src/doc.rs
@@ -22,12 +22,13 @@ pub trait StaticDoc<'a>: DocPtr<'a> {
 ///
 /// The `T` parameter is used to abstract over pointers to `Doc`. See `RefDoc` and `BoxDoc` for how
 /// it is used
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub enum Doc<'a, T>
 where
     T: DocPtr<'a>,
 {
     // Primitives
+    #[default]
     Nil,
     Fail,
 
@@ -95,15 +96,6 @@ where
         DocBuilder(T::ALLOCATOR, self.into())
             .flat_alt(doc)
             .into_plain_doc()
-    }
-}
-
-impl<'a, T> Default for Doc<'a, T>
-where
-    T: DocPtr<'a>,
-{
-    fn default() -> Self {
-        Self::Nil
     }
 }
 
@@ -396,9 +388,16 @@ macro_rules! impl_doc_methods {
                 Doc::Fail.into()
             }
 
-            /// A single hardline.
+            /// A single hard line.
+            #[deprecated(note = "use `hard_line` instead")]
             #[inline]
             pub fn hardline() -> Self {
+                Doc::HardLine.into()
+            }
+
+            /// A single hard line.
+            #[inline]
+            pub fn hard_line() -> Self {
                 Doc::HardLine.into()
             }
 
@@ -420,13 +419,13 @@ macro_rules! impl_doc_methods {
             /// A line acts like a `\n` but behaves like `space` if it is grouped on a single line.
             #[inline]
             pub fn line() -> Self {
-                Self::hardline().flat_alt(Self::space()).into()
+                Self::hard_line().flat_alt(Self::space()).into()
             }
 
             /// Acts like `line` but behaves like `nil` if grouped on a single line
             #[inline]
             pub fn line_() -> Self {
-                Self::hardline().flat_alt(Self::nil()).into()
+                Self::hard_line().flat_alt(Self::nil()).into()
             }
         }
     };

--- a/src/render/fit.rs
+++ b/src/render/fit.rs
@@ -284,7 +284,7 @@ where
                     }
 
                     Doc::HardLine => {
-                        // A hardline only “fits” in break mode.
+                        // A hard_line only “fits” in break mode.
                         return mode == Mode::Break;
                     }
 

--- a/tests/contextual.rs
+++ b/tests/contextual.rs
@@ -47,7 +47,7 @@ fn hang_comment() {
         chain!["let", BoxDoc::line(), "x", BoxDoc::line(), "="].group(),
         nest_on_line(chain![
             "\\y ->",
-            nest_on_line(chain!["// abc", BoxDoc::hardline(), body])
+            nest_on_line(chain!["// abc", BoxDoc::hard_line(), body])
         ]),
     ]
     .group();

--- a/tests/render.rs
+++ b/tests/render.rs
@@ -36,7 +36,7 @@ fn newline_in_text() {
 fn forced_newline() {
     let doc = BoxDoc::group(
         BoxDoc::text("test")
-            .append(BoxDoc::hardline())
+            .append(BoxDoc::hard_line())
             .append(BoxDoc::text("test")),
     );
 
@@ -58,12 +58,12 @@ fn space_do_not_reset_pos() {
     ");
 }
 
-// Tests that the `BoxDoc::hardline()` does not cause the rest of document to think that it fits on
+// Tests that the `BoxDoc::hard_line()` does not cause the rest of document to think that it fits on
 // a single line but instead breaks on the `BoxDoc::line()` to fit with 6 columns
 #[test]
 fn newline_does_not_cause_next_line_to_be_to_long() {
     let doc = RcDoc::group(
-        RcDoc::text("test").append(RcDoc::hardline()).append(
+        RcDoc::text("test").append(RcDoc::hard_line()).append(
             RcDoc::text("test")
                 .append(RcDoc::line())
                 .append(RcDoc::text("test")),
@@ -82,7 +82,7 @@ fn newline_after_group_does_not_affect_it() {
     let arena = Arena::new();
     let doc = arena.text("x").append(arena.line()).append("y").group();
 
-    test_snapshot!(100, doc.append(arena.hardline()).1, @"x y");
+    test_snapshot!(100, doc.append(arena.hard_line()).1, @"x y");
 }
 
 #[test]
@@ -115,7 +115,7 @@ fn block_with_hardline() {
             .append(
                 RcDoc::line()
                     .append(RcDoc::text("test"))
-                    .append(RcDoc::hardline())
+                    .append(RcDoc::hard_line())
                     .append(RcDoc::text("test"))
                     .nest(2),
             )
@@ -138,7 +138,7 @@ fn block_with_hardline_negative_nest() {
             .append(
                 RcDoc::line()
                     .append(RcDoc::text("test"))
-                    .append(RcDoc::hardline())
+                    .append(RcDoc::hard_line())
                     .append(RcDoc::text("test"))
                     .nest(-2),
             )
@@ -162,7 +162,7 @@ fn line_comment() {
                 BoxDoc::line()
                     .append(BoxDoc::text("test"))
                     .append(BoxDoc::line())
-                    .append(BoxDoc::text("// a").append(BoxDoc::hardline()))
+                    .append(BoxDoc::text("// a").append(BoxDoc::hard_line()))
                     .append(BoxDoc::text("test"))
                     .nest(2),
             )
@@ -190,7 +190,7 @@ fn hang2(
         .nest(2)
         .group()
         .append(trailer.clone());
-    let body2 = BoxDoc::hardline()
+    let body2 = BoxDoc::hard_line()
         .append(body.clone())
         .nest(2)
         .group()
@@ -275,7 +275,7 @@ fn line_suffix_with_union2() {
 
     let doc = arena.line_suffix(" // 1")
         + arena.text("a")
-        + (arena.line_suffix(" // 3") + arena.hardline() + arena.text("xxxxxxx"))
+        + (arena.line_suffix(" // 3") + arena.hard_line() + arena.text("xxxxxxx"))
             .union(arena.line_suffix(" // 4") + arena.text("yyy"));
 
     test_snapshot!(5, doc, @"ayyy // 1 // 4");


### PR DESCRIPTION
This is an API ~~breaking~~ change for naming consistency with the upcoming `weak_line` and `weak_space`. `hardline` is kept for compatibility.